### PR TITLE
Fix: Enable C# 8.0 for nullable reference types.

### DIFF
--- a/SourceCode/GeographyQuizApp/GeographyQuizApp.csproj
+++ b/SourceCode/GeographyQuizApp/GeographyQuizApp.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Modified the GeographyQuizApp.csproj to specify <LangVersion>8.0</LangVersion>. This allows the use of C# 8.0 features, including nullable reference types, and should resolve build errors related to this feature not being available in C# 7.3 (the default for .NET Framework 4.7.2 projects).